### PR TITLE
[FIX] Use always softbreak

### DIFF
--- a/lib/inlines.js
+++ b/lib/inlines.js
@@ -1059,16 +1059,7 @@ var parseString = function(block) {
 // Parse a newline.  If it was preceded by two spaces, return a hard
 // line break; otherwise a soft line break.
 var parseNewline = function(block) {
-    this.pos += 1; // assume we're at a \n
-    // check previous node for trailing spaces
-    var lastc = block._lastChild;
-    if (lastc && lastc.type === 'text' && lastc._literal[lastc._literal.length - 1] === ' ') {
-        var hardbreak = lastc._literal[lastc._literal.length - 2] === ' ';
-        lastc._literal = lastc._literal.replace(reFinalSpace, '');
-        block.appendChild(new Node(hardbreak ? 'linebreak' : 'softbreak'));
-    } else {
-        block.appendChild(new Node('softbreak'));
-    }
+    block.appendChild(new Node('softbreak'));
     this.match(reInitialSpace); // gobble leading spaces in next line
     return true;
 };


### PR DESCRIPTION
A line break (not in a code span or HTML tag) that is preceded by two or more spaces is parsed as a linebreak (rendered in HTML as a tag)