### PR TITLE
fix: closing code_block

### DIFF
--- a/dist/commonmark.js
+++ b/dist/commonmark.js
@@ -9093,7 +9093,7 @@
 
     var reCodeFence = /^`{3,}(?!.*`)|^~{3,}(?!.*~)/;
 
-    var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/;
+    var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/m;
 
     var reSetextHeadingLine = /^(?:=+|-+)[ \t]*$/;
 

--- a/dist/commonmark.js
+++ b/dist/commonmark.js
@@ -9093,7 +9093,7 @@
 
     var reCodeFence = /^`{3,}(?!.*`)|^~{3,}(?!.*~)/;
 
-    var reClosingCodeFence = /^(?:`{3,}|~{3,})(?= *$)/;
+    var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/;
 
     var reSetextHeadingLine = /^(?:=+|-+)[ \t]*$/;
 
@@ -10505,7 +10505,6 @@
                     if (node.size.width) {
                       this.lit('" width="' + node.size.width);
                     }
-            
                     if (node.size.height) {
                       this.lit('" height="' + node.size.height);
                     }

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -49,7 +49,7 @@ var reATXHeadingMarker = /^#{1,6}(?:[ \t]+|$)/;
 
 var reCodeFence = /^`{3,}(?!.*`)|^~{3,}(?!.*~)/;
 
-var reClosingCodeFence = /^(?:`{3,}|~{3,})(?= *$)/;
+var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/;
 
 var reSetextHeadingLine = /^(?:=+|-+)[ \t]*$/;
 

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -49,7 +49,7 @@ var reATXHeadingMarker = /^#{1,6}(?:[ \t]+|$)/;
 
 var reCodeFence = /^`{3,}(?!.*`)|^~{3,}(?!.*~)/;
 
-var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/;
+var reClosingCodeFence = /^(?:`{3,}|~{3,})(?=( |\n)*$)/m;
 
 var reSetextHeadingLine = /^(?:=+|-+)[ \t]*$/;
 


### PR DESCRIPTION
Closes #3 

It's fixing the regex to close the code blocks at these lines: https://github.com/RocketChat/commonmark.js/blob/bb03ae0b380152a3286f910fddc9d4d66a978ad4/dist/commonmark.js#L9417-L9426

Before, the regex was catching only if you did a single white space or one break line, if you added more then one break line at the end of the three backtick, the regex wasn't catching it and the block was never "closing". Also, I added the `m` to catch more then one code block in a single message, otherwise the regex was wrong.


# Screenshots

#### Before
<img width="320" alt="Screen Shot 2024-02-01 at 14 06 24" src="https://github.com/RocketChat/commonmark.js/assets/47038980/5bd866a6-718d-408f-9564-601dd5cba448">


#### After
<img width="320" alt="Screen Shot 2024-02-01 at 14 05 40" src="https://github.com/RocketChat/commonmark.js/assets/47038980/ac6412cc-6e92-4e68-af64-e5e7e032b01a">


[TC-1093]

[TC-1093]: https://rocketchat.atlassian.net/browse/TC-1093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ